### PR TITLE
Updated direction about changed default `USB device ID`

### DIFF
--- a/CanbusKlipper/Klipper/README.md
+++ b/CanbusKlipper/Klipper/README.md
@@ -24,6 +24,7 @@
       * Micro-controller Architecture = `STMicroelectronics STM32`
       * Processor model = `STM32F072`(Note: You can set `Processor model` to `STM32F070` or wait for [PR](https://github.com/Klipper3d/klipper/pull/4799) to merge into the master branch and use the latest version of klipper firmware if your firmware has no USB option for `STM32F072`)
       * Clock Reference = `8 MHz crystal)`
+      * Bootloader offset = `No bootloader`
       * IF USE USB
          * Communication interface = `USB (on PA11/PA12)`
          * USB ids `0x1d50` for USB vender ID, and `0x614f` for USB device ID. (Note: it is important that hte USB device ID is not the default `0x614e` assigned by Klipper as this causes the device to lose connection during `FIRMWARE_RESTART`

--- a/CanbusKlipper/Klipper/README.md
+++ b/CanbusKlipper/Klipper/README.md
@@ -26,6 +26,7 @@
       * Clock Reference = `8 MHz crystal)`
       * IF USE USB
          * Communication interface = `USB (on PA11/PA12)`
+         * USB ids `0x1d50` for USB vender ID, and `0x614f` for USB device ID. (Note: it is important that hte USB device ID is not the default `0x614e` assigned by Klipper as this causes the device to lose connection during `FIRMWARE_RESTART`
       * ElSE IF USE CANBUS
          * Communication interface = `CAN bus (on PB8/PB9)`
          * CAN bus speed = 250000 ([firmware-F072-Canbus.bin](./firmware-F072-Canbus.bin) default speed is 250K, You can set it by yourself, But you need to reduce the speed if the communication fails)


### PR DESCRIPTION
This is a fix in the directions of the firmware for issue #14 